### PR TITLE
fix list URL

### DIFF
--- a/src/docs/software/modules.md
+++ b/src/docs/software/modules.md
@@ -382,7 +382,7 @@ $ ml av
 
 [url_lmod]:         //lmod.readthedocs.io
 [url_lmod_user]:    //lmod.readthedocs.io/en/latest/010_user.html
-[url_list]:         list
+[url_list]:         /docs/software/list/
 [url_install]:      /docs/software/install
 [url_contact]:      mailto:srcc-support@stanford.edu
 


### PR DESCRIPTION
was getting a 404 list now /docs/software/list/