### PR TITLE
adding .all-contributorsrc

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,87 @@
+{
+    "projectName": "www.sherlock.stanford.edu",
+    "projectOwner": "stanford-rc",
+    "repoType": "github",
+    "repoHost": "https://github.com",
+    "files": [
+        "README.md"
+    ],
+    "imageSize": 100,
+    "commit": true,
+    "commitConvention": "none",
+    "contributors": [
+        {
+            "login": "kcgthb",
+            "name": "Kilian Cavalotti",
+            "avatar_url": "https://avatars1.githubusercontent.com/u/186807?v=4",
+            "profile": "https://github.com/kcgthb",
+            "contributions": [
+                "doc"
+            ]
+        },
+        {
+            "login": "mpiercy",
+            "name": "Mark Piercy",
+            "avatar_url": "https://avatars0.githubusercontent.com/u/4501682?v=4",
+            "profile": "https://github.com/mpiercy",
+            "contributions": [
+                "doc"
+            ]
+        },
+        {
+            "login": "thiell",
+            "name": "thiell",
+            "avatar_url": "https://avatars1.githubusercontent.com/u/1494929?v=4",
+            "profile": "https://github.com/thiell",
+            "contributions": [
+                "doc"
+            ]
+        },
+        {
+            "login": "vsoch",
+            "name": "Vanessasaurus",
+            "avatar_url": "https://avatars0.githubusercontent.com/u/814322?v=4",
+            "profile": "https://vsoch.github.io",
+            "contributions": [
+                "doc"
+            ]
+        },
+        {
+            "login": "biosafetylvl5",
+            "name": "BSL-5",
+            "avatar_url": "https://avatars0.githubusercontent.com/u/9918036?v=4",
+            "profile": "https://github.com/biosafetylvl5",
+            "contributions": [
+                "doc"
+            ]
+        },
+        {
+            "login": "bentyeh",
+            "name": "Benjamin Yeh",
+            "avatar_url": "https://avatars3.githubusercontent.com/u/8296169?v=4",
+            "profile": "https://bentyeh.github.io",
+            "contributions": [
+                "doc"
+            ]
+        },
+        {
+            "login": "ianfoster",
+            "name": "Ian Foster",
+            "avatar_url": "https://avatars2.githubusercontent.com/u/2997421?v=4",
+            "profile": "https://github.com/ianfoster",
+            "contributions": [
+                "doc"
+            ]
+        },
+        {
+            "login": "romxero",
+            "name": "_RC_",
+            "avatar_url": "https://avatars2.githubusercontent.com/u/1442911?v=4",
+            "profile": "https://github.com/romxero",
+            "contributions": [
+                "doc"
+            ]
+        }
+    ],
+    "contributorsPerLine": 7
+}

--- a/README.md
+++ b/README.md
@@ -15,12 +15,39 @@ process, please see [INTERNALS.md](INTERNALS.md)
 
 ## How to contribute
 
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
+
 We're following the fork, commit, pull-request classical GitHub workflow, as
 described in the [Forking projects][url_gh_guide] GitHub guide:
 
 1. [Fork the repository on GitHub][url_fork]
 2. Make your changes, commit and push them to your repository
 3. Create a new Pull Request
+
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/kcgthb"><img src="https://avatars1.githubusercontent.com/u/186807?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Kilian Cavalotti</b></sub></a><br /><a href="https://github.com/stanford-rc/www.sherlock.stanford.edu/commits?author=kcgthb" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/mpiercy"><img src="https://avatars0.githubusercontent.com/u/4501682?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mark Piercy</b></sub></a><br /><a href="https://github.com/stanford-rc/www.sherlock.stanford.edu/commits?author=mpiercy" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/thiell"><img src="https://avatars1.githubusercontent.com/u/1494929?v=4?s=100" width="100px;" alt=""/><br /><sub><b>thiell</b></sub></a><br /><a href="https://github.com/stanford-rc/www.sherlock.stanford.edu/commits?author=thiell" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://vsoch.github.io"><img src="https://avatars0.githubusercontent.com/u/814322?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Vanessasaurus</b></sub></a><br /><a href="https://github.com/stanford-rc/www.sherlock.stanford.edu/commits?author=vsoch" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/biosafetylvl5"><img src="https://avatars0.githubusercontent.com/u/9918036?v=4?s=100" width="100px;" alt=""/><br /><sub><b>BSL-5</b></sub></a><br /><a href="https://github.com/stanford-rc/www.sherlock.stanford.edu/commits?author=biosafetylvl5" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://bentyeh.github.io"><img src="https://avatars3.githubusercontent.com/u/8296169?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Benjamin Yeh</b></sub></a><br /><a href="https://github.com/stanford-rc/www.sherlock.stanford.edu/commits?author=bentyeh" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/ianfoster"><img src="https://avatars2.githubusercontent.com/u/2997421?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ian Foster</b></sub></a><br /><a href="https://github.com/stanford-rc/www.sherlock.stanford.edu/commits?author=ianfoster" title="Documentation">📖</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/romxero"><img src="https://avatars2.githubusercontent.com/u/1442911?v=4?s=100" width="100px;" alt=""/><br /><sub><b>_RC_</b></sub></a><br /><a href="https://github.com/stanford-rc/www.sherlock.stanford.edu/commits?author=romxero" title="Documentation">📖</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
 
 
 ### Step by step instructions


### PR DESCRIPTION
I think whenever necessary, we should start making an effort to emphasize / reward contributions from users, non-srcc folks, for our documentation repos. The [all-contributors](https://allcontributors.org/) tool is a well known, easy to use tool that can do that! You can see a quick preview of the generated content in the README [here](https://github.com/singularityhub/sregistry). You can even tweak the kind of contributions (from doc to code to infra, there is a whole list!) https://allcontributors.org/docs/en/emoji-key

For automation we have a few options. We can install the [bot](https://allcontributors.org/docs/en/bot/installation) to interact with it in comments (e.g., as soon as someone issues a PR / issue we can tell the bot to add them, and the README is updated by the bot), or I can generate an automated job to update contributors once a month using the GitHub api, there is a python library that handles that nicely. I can add this for a second PR, whatever the choice be! Probably after that people might want to tweak the emoji / types for their contributions too

Signed-off-by: vsoch <vsochat@stanford.edu>