### PR TITLE
Update singularity.md

### DIFF
--- a/src/docs/software/containers/singularity.md
+++ b/src/docs/software/containers/singularity.md
@@ -113,7 +113,7 @@ when assembling the image, so requesting multiple cores in your job can make
 the pull operation faster:
 
 ``` shell
-$ srun -c 4 --pty bash
+$ sh_dev -c 4
 ```
 
 We recommend storing Singularity images in `$GROUP_HOME`, as container images


### PR DESCRIPTION
users would wait too long for srun -c --pty bash since it would default to normal partition, much faster to do sh_dev -c 4