### PR TITLE
fix: prevent deployment on pull requests in check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,7 @@ jobs:
       - run: |
           pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git@${MKM_VER}
           pip install -r requirements.txt
-          mkdocs gh-deploy --force
+          mkdocs build
 
 
   yamllint: # ----------------------------------------------------------------


### PR DESCRIPTION
## Problem
- The check.yml workflow was using `mkdocs gh-deploy --force` which attempts to deploy to GitHub Pages from pull requests
- This causes deployment protection rule conflicts
- The gh-pages branch has incorrect content (Aesop Blog instead of Sherlock docs)

## Solution
- Changed check.yml to use `mkdocs build` instead
- This ensures PRs only test the build without deploying
- Once merged to main, the deploy.yml workflow will properly redeploy the correct Sherlock documentation

## Changes
- `.github/workflows/check.yml` line 31: `mkdocs gh-deploy --force` → `mkdocs build`