### PR TITLE
update devtools installation instructions

### DIFF
--- a/src/docs/software/using/R.md
+++ b/src/docs/software/using/R.md
@@ -441,7 +441,7 @@ $ sh_dev -c 4
 
 $ ml purge
 $ ml R/4.4.2
-$ ml libgit2/1.9.1 fribidi/1.0.12 libwebp/1.3.0
+$ ml libgit2/1.9.1 fribidi/1.0.12 libwebp/1.3.0 freetype/2.9.1
 
 # Launch R and install devtools
 


### PR DESCRIPTION
For some reason the systemfonts package can only be successfully installed if freetype is at the beginning of $PATH.